### PR TITLE
Enable the version of the package to be accessed programatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import setuptools
+import supernnova
 
 setuptools.setup(
     name="supernnova",
-    version="1.3",
+    version=supernnova.__version__,
     author="Anais Moller and Thibault de Boissiere",
     author_email="anais.moller@clermont.in2p3.fr",
     description="framework for Bayesian, Neural Network based supernova light-curve classification",

--- a/supernnova/__init__.py
+++ b/supernnova/__init__.py
@@ -1,1 +1,2 @@
 name = "supernnova"
+__version__ = '1.3'


### PR DESCRIPTION
This PR enables to access more simply the version of the package using:

```python
import supernnova
print(supernnova.__version__)
# 1.3
```

The variable is now stored in `supernnova/__init__.py` instead of the `setup.py`.