### PR TITLE
DES5YR compatibility of filter name change DES-

### DIFF
--- a/python/supernnova/utils/experiment_settings.py
+++ b/python/supernnova/utils/experiment_settings.py
@@ -223,6 +223,8 @@ class ExperimentSettings:
             i
             for (i, f) in enumerate(self.all_features)
             if f in self.training_features_to_normalize
+            or f.replace("DES-", "")
+            in self.training_features_to_normalize  # Horrible fix for new SNANA format
         ]
 
         self.d_feat_to_idx = {f: i for i, f in enumerate(self.all_features)}

--- a/python/supernnova/utils/training_utils.py
+++ b/python/supernnova/utils/training_utils.py
@@ -243,6 +243,15 @@ def load_HDF5(settings, test=False):
         training_features_data = hf["features"][:].astype(str)
         training_features = settings.training_features
 
+        # DES5YR backward compatibility
+        # not very robust
+        if not set(training_features) <= set(training_features_data) and any(
+            "DES-" in k for k in training_features_data
+        ):
+            training_features_data = [
+                k.replace("DES-", "") for k in training_features_data
+            ]
+
         # check if all model features are in db
         assert set(training_features) <= set(training_features_data)
         lu.print_green("Features used", " ".join(training_features))


### PR DESCRIPTION
Closes [issue 74](https://github.com/supernnova/SuperNNova/issues/74)

Test done:

snn validate_rnn  --sntypes '{"1": "Ia", "11": "II", "20": "II", "91": "II", "111": "II", "120": "II", "191": "II", "10": "Ia", "110": "Ia"}' --list_filters DES-g DES-i DES-r DES-z --batch_size 128 --num_layers 2 --hidden_dim 32 --dump_dir $DES_PATH/SNNTESTV19_z_data_4_DATADESCCSIM_SNNTRAINV19_z_TRAINDES_V19/dump --cyclic --model vanilla --model_files $DES_PATH/SNNTRAINV19_z_TRAINDES_V19/model.pt  --redshift zspe --norm cosmo  --debug