### PR TITLE
missing sntypes handling to contaminants

### DIFF
--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -25,6 +25,9 @@ Argument                  Type                Help
 --no_overwrite            bool        If True, overwrite preprocessed dir when creating database
 --data_fraction           float       Fraction of data to use
 --override_source_data    str         Change the source data (use saltfit or photometry)
+--sntypes                 dict        SN type mapping (e.g. '{"101":"Ia","120":"IIP"}'). Types in data not listed here are auto-assigned to a ``contaminant`` class.
+--sntype_var              str         Column name for event types (default: SNTYPE)
+--nb_classes              int         Number of classification targets (default: 2)
 ======================  ============  ==================================================================
 
 Training parameters

--- a/docs/installation/FAQ.rst
+++ b/docs/installation/FAQ.rst
@@ -84,6 +84,10 @@ You have probably forgotten to set your ``dump_dir`` correctly. Provide the ``--
 - **ValueError: No objects to concatenate in Database creation**
 Check that you provided the appropriate ``raw_dir`` and that the files are either .FITS tables or .csv with the proper format (see data tab). Another possibility is that you are using a different survey than DES and you need to specify the appropriate ``list_filters``.
 
+- **ValueError during training when using a custom** ``--sntypes`` **with only a subset of types**
+
+Previously, if your data contained types not listed in ``--sntypes``, training would fail with a ``ValueError`` because the missing types were assigned to an out-of-bounds class index. This has been fixed: missing types are now automatically assigned to a ``contaminant`` class. You only need to specify the types you want to distinguish in ``--sntypes``. See :ref:`DataStructure` for details on how contaminant auto-detection works.
+
 - **Your error not here? Please open an issue in GitHub! **
 
 


### PR DESCRIPTION
Closes [issue/71](https://github.com/supernnova/SuperNNova/issues/71)
Missing untypes are now robustly sent to a new type called "contaminants"
Warning is printed